### PR TITLE
Don't send Travis notifications to the OpenSTF team

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,3 @@ cache:
   directories:
     - node_modules
     - res/bower_components
-
-notifications:
-  slack: openstf:qu01BtEgttJOrGGsRxKBJwki


### PR DESCRIPTION
Currently, your repo is not actually a fork but rather an import of OpenSTF files. That's perfectly fine, the license allows you to do that. However, since it's not a direct fork and you seem to have set up Travis yourself, Travis is submitting build notifications to us. Since you also have greenkeeper enabled, we're essentially getting every notification twice on our channel. Please change the channel or merge this patch to remove the notification.
